### PR TITLE
Release v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ description = "Read in STL files"
 name = "stl-reader"
 readme = "README.rst"
 requires-python = ">=3.8"
-version = "0.2.dev0"
+version = "0.3.dev0"
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only


### PR DESCRIPTION
Bump to 0.3.dev0 in preparation for a release of `v0.2.0`.
