### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.22.0
 
     - uses: actions/upload-artifact@v4
       with:
@@ -39,7 +39,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Build sdist
       run: pipx run build --sdist
@@ -72,7 +72,7 @@ jobs:
     - name: List artifacts
       run: ls -R
 
-    - uses: pypa/gh-action-pypi-publish@v1.9.0
+    - uses: pypa/gh-action-pypi-publish@v1.12.2
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.9
+  rev: v0.8.0
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -39,7 +39,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.11.2
+  rev: v1.13.0
   hooks:
   - id: mypy
     additional_dependencies: [numpy>=2.0, npt-promote==0.1]
@@ -54,12 +54,12 @@ repos:
     args: [--autofix, --indent, '2']
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v19.1.1
+  rev: v19.1.4
   hooks:
   - id: clang-format
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.29.3
+  rev: 0.29.4
   hooks:
   - id: check-github-workflows
 

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,10 @@
    :target: https://opensource.org/licenses/MIT
 
 ``stl-reader`` is a Python library for raipidly reading binary STL
-files. It wraps a Cython interface to the fast STL library provided by
-`libstl <https://github.com/aki5/libstl>`_. Thanks @aki5!
+files. It wraps a `nanobind
+<https://nanobind.readthedocs.io/en/latest/>`_ interface to the fast STL
+library provided by `libstl <https://github.com/aki5/libstl>`_. Thanks
+@aki5!
 
 The main advantage of ``stl-reader`` over other STL reading libraries is
 its performance. It is particularly well-suited for large files, mainly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ classifiers = [
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX",
   "Intended Audience :: Science/Research",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12"
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
   "numpy"
@@ -23,12 +23,12 @@ dependencies = [
 description = "Read in STL files"
 name = "stl-reader"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 version = "0.3.dev0"
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only
-skip = "cp36-* cp37-* pp* *musllinux*"  # disable PyPy and musl-based wheels
+skip = "cp37-* pp* *musllinux*"  # disable PyPy and musl-based wheels
 test-command = "pytest {project}/tests"
 test-requires = "pytest pyvista"
 


### PR DESCRIPTION
Add support for Python 3.13.

Also:
- Bump pre-commit
- Bump cibuildwheel and other github actions
