### PR TITLE
use int32

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,9 @@ ci:
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.4
+  rev: v0.11.12
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix]
     exclude: ^(docs/|tests)
   - id: ruff-format
@@ -39,7 +39,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.15.0
+  rev: v1.16.0
   hooks:
   - id: mypy
     additional_dependencies: [numpy>=2.0, npt-promote==0.1]
@@ -54,12 +54,12 @@ repos:
     args: [--autofix, --indent, '2']
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v20.1.0
+  rev: v20.1.5
   hooks:
   - id: clang-format
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.32.1
+  rev: 0.33.0
   hooks:
   - id: check-github-workflows
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -80,3 +80,4 @@ def test_read_as_mesh() -> None:
 
     stl_mesh = stl_reader.read_as_mesh(TEST_FILE_BINARY)
     assert pv_mesh == stl_mesh
+    assert stl_mesh._connectivity_array.dtype == np.int32


### PR DESCRIPTION
Use int32 rather than int64 in `read_as_array`. Internally, stl-reader already records faces as np.uint32 and it's not necessary unless the number of vertices exceeds overflow to use int64. Checks for overflow and then selects the best dtype for memory efficiency.
