### PR TITLE
Use fixed-size storage for STL triangles

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,12 +28,12 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest, macos-15-intel]
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         fetch-depth: 0  # required for setuptools_scm
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55  # v4.1.0
+      uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c  # v4.1.1
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
@@ -44,11 +44,11 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         fetch-depth: 0  # required for setuptools_scm
 
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.13'
 
@@ -93,7 +93,7 @@ jobs:
         pattern: pyvista-stl-*
     - run: ls -alR dist/
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
     - name: Create GitHub Release
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.9
+  rev: v0.15.20
   hooks:
   - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix]
@@ -46,7 +46,7 @@ repos:
     args: [--maxkb=500]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.20.0
+  rev: v2.1.0
   hooks:
   - id: mypy
     additional_dependencies: [numpy>=2.0, npt-promote==0.1]
@@ -61,12 +61,12 @@ repos:
     args: [--autofix, --indent, '2']
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v22.1.2
+  rev: v22.1.5
   hooks:
   - id: clang-format
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.37.1
+  rev: 0.37.4
   hooks:
   - id: check-github-workflows
 

--- a/src/pyvista_stl/reader.py
+++ b/src/pyvista_stl/reader.py
@@ -46,6 +46,7 @@ def _polydata_from_faces(
 
     """
     try:
+        from pyvista import vtk_version_info
         from pyvista.core.pointset import PolyData
     except ModuleNotFoundError as exc:
         msg = "pyvista_stl.read_as_mesh requires PyVista. Install it with: pip install pyvista"
@@ -67,15 +68,19 @@ def _polydata_from_faces(
         msg = f"Unsupported face dtype {faces.dtype!r}; expected int32 or int64."
         raise TypeError(msg)
 
-    offset = np.arange(0, faces.size + 1, faces.shape[1], dtype=faces.dtype)
-    offset_vtk = numpy_to_vtk(offset, deep=False, array_type=vtk_dtype)
     faces_vtk = numpy_to_vtk(faces.ravel(), deep=False, array_type=vtk_dtype)
 
     carr = vtkCellArray()
-    carr.SetData(offset_vtk, faces_vtk)
+    if vtk_version_info >= (9, 6, 2):
+        carr.SetData(faces.shape[1], faces_vtk)
+    else:
+        offset = np.arange(0, faces.size + 1, faces.shape[1], dtype=faces.dtype)
+        offset_vtk = numpy_to_vtk(offset, deep=False, array_type=vtk_dtype)
+        carr.SetData(offset_vtk, faces_vtk)
+        carr._offset_np_ref = offset_vtk
+
     # Keep references on the cell array so the underlying numpy buffers
     # are not garbage-collected while VTK still holds raw pointers.
-    carr._offset_np_ref = offset_vtk
     carr._faces_np_ref = faces_vtk
 
     pdata = PolyData()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -91,6 +91,9 @@ def test_read_as_mesh() -> None:
     assert pv_mesh == stl_mesh
     assert stl_mesh._connectivity_array.dtype == np.int32
 
+    if pv.vtk_version_info >= (9, 6, 2):
+        assert stl_mesh.GetPolys().IsStorageFixedSize()
+
 
 def test_entry_point_registered() -> None:
     """``read_as_mesh`` is advertised on the ``pyvista.readers`` group."""

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -183,7 +183,7 @@ def test_seq_and_mt_agree_on_grid(stl_dir: Path) -> None:
         cells = pts[idx]
         cells = np.sort(cells, axis=1)
         flat = cells.reshape(cells.shape[0], -1)
-        return cells[np.lexsort(flat.T[::-1])]
+        return np.asarray(cells[np.lexsort(flat.T[::-1])])
 
     np.testing.assert_array_equal(_canon(pts_seq, idx_seq), _canon(pts_mt, idx_mt))
 


### PR DESCRIPTION
## Summary

Use VTK's fixed-size cell storage for STL triangle connectivity on VTK 9.6.2 and newer. This keeps offsets implicit and removes one `int32` offset allocation per triangle. Older VTK versions retain the existing explicit-offset path, selected with `pyvista.vtk_version_info`.

This PR also updates the pre-commit hooks, fixes the stricter mypy finding exposed by that update, and consolidates the open GitHub Actions dependency updates. It supersedes #45, #47, #48, #49, and #50.

## Benchmarks

Intel Xeon E-2288G, Python 3.12.12, NumPy 2.5.1, PyVista 0.48.4, and VTK 9.6.2. Each result is the median of 21 paired samples on one pinned CPU core, with execution order alternated after five warmup runs.

| Triangles | Explicit offsets | Fixed size | Speedup | Offset allocation removed |
| ---: | ---: | ---: | ---: | ---: |
| 100,000 | 358.88 us | 273.46 us | 1.31x | 0.40 MB |
| 1,000,000 | 1,212.57 us | 302.03 us | 4.01x | 4.00 MB |

<details>
<summary>Benchmark script</summary>

```python
"""Compare generic-offset and fixed-size vtkCellArray construction."""

import gc
import platform
import statistics
import sys
import time

import numpy as np
import pyvista as pv
from pyvista.core.pointset import PolyData
from pyvista_stl.reader import _polydata_from_faces
from vtkmodules.util.numpy_support import numpy_to_vtk
from vtkmodules.vtkCommonCore import vtkTypeInt32Array
from vtkmodules.vtkCommonDataModel import vtkCellArray


def build_with_offsets(points: np.ndarray, faces: np.ndarray) -> PolyData:
    """Build polydata using an explicit offset array."""
    vtk_dtype = vtkTypeInt32Array().GetDataType()
    offsets = np.arange(0, faces.size + 1, faces.shape[1], dtype=faces.dtype)
    offsets_vtk = numpy_to_vtk(offsets, deep=False, array_type=vtk_dtype)
    faces_vtk = numpy_to_vtk(faces.ravel(), deep=False, array_type=vtk_dtype)
    cells = vtkCellArray()
    cells.SetData(offsets_vtk, faces_vtk)
    cells._offset_np_ref = offsets_vtk
    cells._faces_np_ref = faces_vtk
    mesh = PolyData()
    mesh.points = points
    mesh.SetPolys(cells)
    return mesh


def time_once(function, points: np.ndarray, faces: np.ndarray) -> int:
    """Return one construction time in nanoseconds."""
    start = time.perf_counter_ns()
    mesh = function(points, faces)
    elapsed = time.perf_counter_ns() - start
    del mesh
    gc.collect()
    return elapsed


print(platform.platform())
print(sys.version.split()[0], f"NumPy {np.__version__}", f"PyVista {pv.__version__}")
print(f"VTK {pv.vtk_version_info.major}.{pv.vtk_version_info.minor}.{pv.vtk_version_info.micro}")

for n_cells in (100_000, 1_000_000):
    points = np.zeros((3, 3), dtype=np.float32)
    faces = np.zeros((n_cells, 3), dtype=np.int32)

    for _ in range(5):
        time_once(build_with_offsets, points, faces)
        time_once(_polydata_from_faces, points, faces)

    offset_times: list[int] = []
    fixed_times: list[int] = []
    for sample in range(21):
        order = (
            (build_with_offsets, offset_times),
            (_polydata_from_faces, fixed_times),
        )
        if sample % 2:
            order = order[::-1]
        for function, values in order:
            values.append(time_once(function, points, faces))

    offset_us = statistics.median(offset_times) / 1_000
    fixed_us = statistics.median(fixed_times) / 1_000
    saved_mb = 4 * (n_cells + 1) / 1_000_000
    print(
        f"{n_cells:,} triangles: offsets={offset_us:.2f} us, "
        f"fixed={fixed_us:.2f} us, speedup={offset_us / fixed_us:.2f}x, "
        f"offset allocation removed={saved_mb:.2f} MB"
    )
```

</details>

## AI Attribution

Used ChatGPT's [GPT-5.6](https://openai.com/index/gpt-5-6/).
