### PR TITLE
Declare the .stl reader in the pyvista.readers.override group

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,14 +102,20 @@ To get a ``pyvista.PolyData`` directly:
      Z Bounds:   -5.551e-17, 5.551e-17
      N Arrays:   0
 
-With ``pyvista >= 0.48`` installed, ``pyvista.read`` automatically
-dispatches ``.stl`` files to ``pyvista_stl`` via the ``pyvista.readers``
-entry point:
+With ``pyvista >= 0.49`` installed, ``pyvista.read`` automatically
+dispatches ``.stl`` files to ``pyvista_stl`` via the
+``pyvista.readers.override`` entry point:
 
 .. code:: pycon
 
    >>> import pyvista as pv
    >>> mesh = pv.read("example.stl")  # uses pyvista_stl
+
+PyVista reads ``.stl`` natively, so this entry point replaces a built-in
+reader and is declared in the ``pyvista.readers.override`` group, which
+states that intent. On ``pyvista`` 0.48 the group is unknown and
+ignored: ``pyvista.read`` keeps using the built-in STL reader, and
+``pyvista_stl.read_as_mesh`` can still be called directly.
 
 ************
  Benchmarks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,10 @@ name = "pyvista-stl"
 readme = "README.rst"
 requires-python = ">=3.10"
 
-# Requires pyvista >= 0.48
-[project.entry-points."pyvista.readers"]
+# ``.stl`` is a format PyVista reads natively, so replacing its reader is an
+# override and has to be declared as one. Requires pyvista >= 0.49; older
+# PyVista ignores this group and keeps using its built-in STL reader.
+[project.entry-points."pyvista.readers.override"]
 ".stl" = "pyvista_stl:read_as_mesh"
 
 [project.optional-dependencies]

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -17,9 +17,11 @@ try:
 
     PYVISTA_INSTALLED = True
     _HAS_READER_REGISTRY = Version(pv.__version__) >= Version("0.48.dev0")
+    _HAS_READER_OVERRIDE = Version(pv.__version__) >= Version("0.49.dev0")
 except ImportError:
     PYVISTA_INSTALLED = False
     _HAS_READER_REGISTRY = False
+    _HAS_READER_OVERRIDE = False
 
 THIS_PATH = os.path.dirname(os.path.abspath(__file__))
 TEST_FILE_ASCII = os.path.join(THIS_PATH, "sphere_ascii.stl")
@@ -96,8 +98,8 @@ def test_read_as_mesh() -> None:
 
 
 def test_entry_point_registered() -> None:
-    """``read_as_mesh`` is advertised on the ``pyvista.readers`` group."""
-    matches = [ep for ep in entry_points(group="pyvista.readers") if ep.name == ".stl"]
+    """``read_as_mesh`` is advertised on the ``pyvista.readers.override`` group."""
+    matches = [ep for ep in entry_points(group="pyvista.readers.override") if ep.name == ".stl"]
     assert matches, "pyvista_stl did not publish a '.stl' entry point"
     assert matches[0].value == "pyvista_stl:read_as_mesh"
     assert matches[0].load() is pyvista_stl.read_as_mesh
@@ -114,9 +116,14 @@ def test_read_raises_for_remote_uri(func: Callable[[str], Any]) -> None:
         func("https://example.com/mesh.stl")
 
 
+def test_stl_is_not_claimed_in_the_plain_group() -> None:
+    """The plain group refuses an extension PyVista reads natively."""
+    assert not [ep for ep in entry_points(group="pyvista.readers") if ep.name == ".stl"]
+
+
 @pytest.mark.skipif(
-    not _HAS_READER_REGISTRY,
-    reason="requires pyvista >= 0.48 reader registry",
+    not _HAS_READER_OVERRIDE,
+    reason="requires pyvista >= 0.49 reader override group",
 )
 def test_pv_read_dispatches_to_entry_point() -> None:
     """``pv.read('*.stl')`` resolves to ``pyvista_stl.read_as_mesh`` via the registry."""


### PR DESCRIPTION
PyVista reads `.stl` natively, and starting with 0.49 a plain `pyvista.readers` entry point is not allowed to claim an extension PyVista already reads: it raises `ValueError` at read time rather than let a plugin silently change what `pv.read()` returns. With this package installed, every `.stl` read in the environment hits that error, which is worse than not having the faster reader at all.

The intended way to replace a built-in reader is the `pyvista.readers.override` group, so the entry point moves there. On PyVista 0.48 that group is unknown and ignored, so `pv.read` falls back to the built-in STL reader and `pyvista_stl.read_as_mesh` still works when called directly. Nothing breaks on older releases; the speedup through `pv.read` needs 0.49.

The dispatch test is now gated on 0.49, and a new test asserts the plain group stays unclaimed.