### PR TITLE
Ship an abi3 wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Repository = "https://github.com/pyvista/pyvista-stl"
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only
-build = "cp310-* cp311-* cp312-* cp313-* cp314*"
+build = "cp310-* cp311-* cp312-*"  # cp312 is abi3 and covers every later 3.x
 skip = " cp314t-* *musllinux*"  # disable musl-based wheels and free threading
 test-command = "pytest {project}/tests"
 test-requires = "pytest pyvista"
@@ -89,6 +89,7 @@ build-dir = "build/{wheel_tag}"
 minimum-version = "0.10"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.exclude = [".github", "*.png", "tests", ".mypy_cache", ".pre-commit-config.yaml", "*_cache", "CONTRIBUTING.md", ".gitignore"]
+wheel.py-api = "cp312"  # nanobind builds STABLE_ABI; one wheel serves 3.12 and later
 
 [tool.setuptools_scm]
 fallback_version = "0.0.0"


### PR DESCRIPTION
`nanobind_add_module` already asks for `STABLE_ABI`, but scikit-build-core was tagging the wheel per-interpreter, so every 3.x needed its own build. `wheel.py-api = "cp312"` tags it abi3; cibuildwheel drops to cp310, cp311 and cp312.

A local build produces `pyvista_stl-...-cp312-abi3-macosx_15_0_arm64.whl` carrying `_core.abi3.so`. That single wheel installs and reads STL on 3.12, 3.13 and 3.14, and the suite passes against it on 3.14 (163 passed, 4 skipped).

Same change as pyvista/pyvista-miniply#26, which also needed it to get a 3.14 wheel at all.

Changes drafted by Claude Opus 5 and reviewed by @akaszynski.